### PR TITLE
auto-compile-on-load-mode after auto-compile

### DIFF
--- a/Sacha.org
+++ b/Sacha.org
@@ -84,7 +84,7 @@ in a directory in my =load-path=, Emacs can find them.
 (require 'use-package)
 (use-package auto-compile
   :ensure t
-  :init (auto-compile-on-load-mode))
+  :config (auto-compile-on-load-mode))
 (setq load-prefer-newer t)
 #+END_SRC
 


### PR DESCRIPTION
I think `auto-compile-on-load-mode` is provided by `auto-compile`, so it should be called only after the package is loaded, yes?
